### PR TITLE
removed keychain interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # add-securetoken-to-logged-in-user
 
-Adds SecureToken to currently logged-in user, allowing that user to unlock FileVault in macOS High Sierra. Uses credentials from a GUI-created admin account (retrieves from a manually-created System keychain entry), and prompts for current user's password.
+Adds SecureToken to currently logged-in user, allowing that user to unlock, enable, or disable FileVault on APFS volumes in macOS High Sierra or later. Prompts for password of SecureToken admin (gets the username from a Jamf script parameter) and logged-in user.
 
-This workflow is currently required to authorize programmatically-created user accounts (that were not already explicitly given a SecureToken) to enable or use FileVault on APFS-formatted startup volumes in macOS High Sierra.
+This workflow is currently required to authorize programmatically-created user accounts (that were not already explicitly given a SecureToken) to enable or use FileVault on APFS-formatted startup volumes in macOS High Sierra or later.
 
 ## Credits
 
 - `sysadminctl` SecureToken syntax discovered and formalized in [MacAdmins Slack](https://macadmins.slack.com) #filevault.
-- AppleScript password prompt snippet found in [Stack Overflow answer](https://stackoverflow.com/a/17816746) from [scohe001](https://stackoverflow.com/users/2602718/scohe001).

--- a/add-securetoken-to-logged-in-user.sh
+++ b/add-securetoken-to-logged-in-user.sh
@@ -3,16 +3,14 @@
 ###
 #
 #            Name:  add-securetoken-to-logged-in-user.sh
-#     Description:  Adds SecureToken to currently logged-in user, allowing that
-#                   user to enable or use FileVault in macOS High Sierra. Uses
-#                   credentials from a GUI-created admin account $guiAdmin
-#                   (retrieves from a manually-created System keychain entry),
-#                   and prompts for current user's password.
+#     Description:  Adds SecureToken to currently logged-in user. Prompts for
+#                   password of SecureToken admin (gets SecureToken Admin
+#                   Username from Jamf script parameter) and logged-in user.
 #                   https://github.com/mpanighetti/add-securetoken-to-logged-in-user
 #          Author:  Mario Panighetti
 #         Created:  2017-10-04
-#   Last Modified:  2018-05-15
-#         Version:  2.2
+#   Last Modified:  2018-11-29
+#         Version:  3.0
 #
 ###
 
@@ -22,14 +20,11 @@
 
 
 
-# replace with username of a GUI-created admin account
-# (or any admin user with SecureToken access)
-guiAdmin="guiadmin-username"
-# This sample script assumes that the $guiAdmin account credentials have
-# already been saved in the System keychain in an entry named "$guiAdmin".
-# If you want to prompt for this information instead of pulling from the
-# keychain, you can copy the osascript from securetoken_add to generate a new
-# prompt, and pass the result to $guiAdminPass.
+# local admin account with SecureToken access
+# Jamf script parameter "SecureToken Admin Username"
+securetokenAdmin="$5"
+# need a default password value so the initial logic loops will properly fail when validating password
+targetUserPass="foo"
 # leave these values as-is
 loggedInUser=$("/usr/bin/stat" -f%Su "/dev/console")
 macosMinor=$("/usr/bin/sw_vers" -productVersion | "/usr/bin/awk" -F . '{print $2}')
@@ -41,80 +36,86 @@ macosBuild=$("/usr/bin/sw_vers" -productVersion | "/usr/bin/awk" -F . '{print $3
 
 
 
-# exit script if macOS < 10.13.3
-macos_check () {
-  if [[ "$macosMinor" -ne 13 ]] || [[ "$macosBuild" -lt 4 ]]; then
-    "/bin/echo" "❌ ERROR: Mac does not meet script requirements (macOS 10.13.4 or later). Update to the latest compatible macOS build, then run script again."
-    exit 70
+#exit with error if any required Jamf arguments are undefined
+check_jamf_arguments () {
+  jamfArguments=(
+    "$securetokenAdmin"
+  )
+  for argument in "${jamfArguments[@]}"; do
+    if [[ "$argument" = "" ]]; then
+      "/bin/echo" "❌ ERROR: Undefined Jamf argument, unable to proceed."
+      exit 74
+    fi
+  done
+}
+
+
+# exit if macOS < 10.13.4
+check_macos () {
+  if [[ "$macosMinor" -lt 13 || ( "$macosMinor" -eq 13 && "$macosBuild" -lt 4 ) ]]; then
+    "/bin/echo" "SecureToken is only required in macOS 10.13.4 or later. No action required."
+    exit 0
   fi
 }
 
 
-# exit script if not runnning as root
-if [[ $EUID -ne 0 ]]; then
-    "/bin/echo" "❌ ERROR: This script must run as root."
+# exit with error if $secureTokenAdmin does not have SecureToken
+check_securetoken_admin () {
+  if [[ $("/usr/sbin/sysadminctl" -secureTokenStatus "$secureTokenAdmin" 2>&1) =~ "DISABLED" ]]; then
+    "/bin/echo" "$secureTokenAdmin does not have a valid SecureToken, unable to proceed. Please update Jamf policy to target another admin user with SecureToken."
     exit 1
-fi
-
-
-# add SecureToken to $loggedInUser account to allow FileVault access
-securetoken_add () {
-  # https://stackoverflow.com/a/17816746
-  loggedInUserPass=$("/usr/bin/osascript" <<EOT
-tell application "System Events"
-  with timeout of 86400 seconds
-    activate
-    set display_text to "$loggedInUser missing SecureToken required for FileVault access. Please enter the user's password."
-    repeat
-      considering case
-        set init_pass to text returned of (display dialog display_text default answer "" with hidden answer)
-        set final_pass to text returned of (display dialog "Please verify the password for $loggedInUser." buttons {"OK"} default button 1 default answer "" with hidden answer)
-        if (final_pass = init_pass) then
-          exit repeat
-        else
-          set display_text to "Passwords do not match, please try again."
-        end if
-      end considering
-    end repeat
-  end timeout
-end tell
-set myReply to final_pass
-EOT
-    )
-  if [[ "$loggedInUserPass" = "" ]]; then
-     "/bin/echo" "❌ ERROR: A password was not entered for $loggedInUser, unable to proceed. Try running the script again; if issue persists, a manual SecureToken add will be required."
-     exit 1
   else
-    guiAdminPass=$("/usr/bin/security" find-generic-password -wa "$guiAdmin" "/Library/Keychains/System.keychain")
-    "/usr/sbin/sysadminctl" \
-      -adminUser "$guiAdmin" \
-      -adminPassword "$guiAdminPass" \
-      -secureTokenOn "$loggedInUser" \
-      -password "$loggedInUserPass"
-    unset guiAdminPass
-    unset loggedInUserPass
+    "/bin/echo" "Verified $secureTokenAdmin has SecureToken."
   fi
+}
 
+
+local_account_password_prompt () {
+  targetUserPass=$("/usr/bin/osascript" <<EOT
+tell application "System Events"
+  activate
+  set display_text to "Please enter password for user $1. $2"
+  set user_password to text returned of (display dialog display_text default answer "" with hidden answer)
+end tell
+set myReply to user_password
+EOT
+  )
+  if [[ "$targetUserPass" = "" ]]; then
+    "/bin/echo" "❌ ERROR: A password was not entered for $1, unable to proceed. Please rerun policy; if issue persists, a manual SecureToken add will be required to continue."
+    exit 1
+  fi
+}
+
+
+local_account_password_validation () {
+  passwordVerify=$("/usr/bin/dscl" /Local/Default authonly "$1" "$2" > "/dev/null" 2>&1; "/bin/echo" $?)
+  if [[ "$passwordVerify" -eq 0 ]]; then
+    "/bin/echo" "✅ Password successfully validated for $1."
+  else
+    "/bin/echo" "❌ Failed password validation for $1. Please reenter the password when prompted."
+  fi
+}
+
+
+# add SecureToken to target user to allow FileVault access
+securetoken_add () {
+  "/usr/sbin/sysadminctl" \
+    -adminUser "$1" \
+    -adminPassword "$2" \
+    -secureTokenOn "$3" \
+    -password "$4"
 
   # verify successful SecureToken add
-  secureTokenCheck=$("/usr/sbin/sysadminctl" -secureTokenStatus "$loggedInUser" 2>&1)
+  secureTokenCheck=$("/usr/sbin/sysadminctl" -secureTokenStatus "$3" 2>&1)
   if [[ "$secureTokenCheck" =~ "DISABLED" ]]; then
-    "/bin/echo" "❌ ERROR: Failed to add SecureToken to $loggedInUser for FileVault access. Try running the script again; if issue persists, a manual SecureToken add will be required."
+    "/bin/echo" "❌ ERROR: Failed to add SecureToken to $3 for FileVault access. Please rerun policy; if issue persists, a manual SecureToken add will be required to continue."
     exit 126
   elif [[ "$secureTokenCheck" =~ "ENABLED" ]]; then
-    "/bin/echo" "✅ Verified SecureToken is enabled for $loggedInUser."
-    cred_clear
+    "/bin/echo" "✅ Verified SecureToken is enabled for $3."
   else
-    "/bin/echo" "❌ ERROR: Unexpected result, unable to proceed. Try running the script again; if issue persists, a manual SecureToken add will be required."
+    "/bin/echo" "❌ ERROR: Unexpected result, unable to proceed. Please rerun policy; if issue persists, a manual SecureToken add will be required to continue."
     exit 1
   fi
-}
-
-
-# delete $guiAdmin credentials from System keychain
-cred_clear () {
-  "/bin/echo" "Removing stored credentials for $guiAdmin..."
-  "/usr/bin/security" delete-generic-password -a "$guiAdmin" "/Library/Keychains/System.keychain"
 }
 
 
@@ -123,18 +124,40 @@ cred_clear () {
 
 
 
-# verify Mac meets system requirements
-macos_check
-root_check
+# exit if any required Jamf arguments are undefined
+check_jamf_arguments
+
+
+# verify Mac is running macOS 10.13.4+
+check_macos
+
+
+# verify $secureTokenAdmin actually has SecureToken
+check_securetoken_admin
 
 
 # add SecureToken to $loggedInUser if missing
-if [[ $("/usr/sbin/sysadminctl" -secureTokenStatus "$loggedInUser" 2>&1) =~ "DISABLED" ]]; then
-  securetoken_add
-else
-  "/bin/echo" "✅ Verified SecureToken is enabled for $loggedInUser."
-  cred_clear
-fi
+while [[ $("/usr/sbin/sysadminctl" -secureTokenStatus "$loggedInUser" 2>&1) =~ "DISABLED" ]]; do
+
+  # get $secureTokenAdmin password
+  "/bin/echo" "$loggedInUser missing SecureToken, prompting for credentials..."
+  while [[ $("/usr/bin/dscl" "/Local/Default" authonly "$securetokenAdmin" "$targetUserPass" > "/dev/null" 2>&1; "/bin/echo" $?) -ne 0 ]]; do
+    local_account_password_prompt "$securetokenAdmin" "User's SecureToken credentials will be used to grant a new SecureToken to $loggedInUser."
+    local_account_password_validation "$securetokenAdmin" "$targetUserPass"
+  done
+  securetokenAdminPass="$targetUserPass"
+
+  # get $loggedInUser password
+  while [[ $("/usr/bin/dscl" "/Local/Default" authonly "$loggedInUser" "$targetUserPass" > "/dev/null" 2>&1; "/bin/echo" $?) -ne 0 ]]; do
+    local_account_password_prompt "$loggedInUser" "Need to add SecureToken for FileVault access."
+    local_account_password_validation "$loggedInUser" "$targetUserPass"
+  done
+  loggedInUserPass="$targetUserPass"
+
+  # add SecureToken using provided credentials
+  securetoken_add "$securetokenAdmin" "$securetokenAdminPass" "$loggedInUser" "$loggedInUserPass"
+
+done
 
 
 


### PR DESCRIPTION
- removed keychain interaction as this was not a universally applicable configuration; script now prompts for both the SecureToken admin and the logged-in user password
- added password validation before SecureToken grant attempt (replaces password double-prompt)
- added explicit Mojave support in version check
- changed check_macos exit to a non-error code for macOS < 10.13.4
- script now assumes it's being run as a Jamf Pro policy (root check removed as all Jamf scripts run as root)