### PR TITLE
Extension attribute

### DIFF
--- a/Add SecureToken to Target User.sh
+++ b/Add SecureToken to Target User.sh
@@ -2,16 +2,36 @@
 
 ###
 #
-#            Name:  Add SecureToken to Logged-In User.sh
-#     Description:  Adds SecureToken to currently logged-in user to prepare system for
-#                   enabling FileVault. Prompts for password of SecureToken admin (gets
-#                   SecureToken Admin Username from Jamf Pro script parameter) and
-#                   logged-in user.
-#                   https://github.com/mpanighetti/add-securetoken-to-logged-in-user
+#            Name:  Add SecureToken to Target User.sh
+#     Description:  This script adds a SecureToken to the target local user to prepare the Mac for enabling FileVault. Prompts for password of SecureToken admin (gets SecureToken Admin Username from Jamf Pro script parameter) and target user. This workflow is required to authorize programmatically-created user accounts (that were not already explicitly given a SecureToken) to enable or use FileVault and unlock disk encryption on APFS-formatted startup volumes.
+#                   https://github.com/mpanighetti/add-securetoken-to-target-user
+#
+#                   MIT License
+#
+#                   Copyright (c) 2017 Mario Panighetti
+#
+#                   Permission is hereby granted, free of charge, to any person obtaining a copy
+#                   of this software and associated documentation files (the "Software"), to deal
+#                   in the Software without restriction, including without limitation the rights
+#                   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#                   copies of the Software, and to permit persons to whom the Software is
+#                   furnished to do so, subject to the following conditions:
+#
+#                   The above copyright notice and this permission notice shall be included in all
+#                   copies or substantial portions of the Software.
+#
+#                   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#                   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#                   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#                   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#                   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#                   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#                   SOFTWARE.
+#
 #          Author:  Mario Panighetti
 #         Created:  2017-10-04
-#   Last Modified:  2023-02-27
-#         Version:  4.0.2
+#   Last Modified:  2025-04-28
+#         Version:  4.1
 #
 ###
 
@@ -23,14 +43,16 @@
 
 # Jamf Pro script parameter: "SecureToken Admin Username"
 # A local administrator account with SecureToken access.
-secureTokenAdmin="${5}"
-loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+secureTokenAdmin="${4}"
+# Jamf Pro script parameter: "Target Username"
+# (optional) A local user account requiring SecureToken. If undefined, script will default to the logged-in user as the target.
+targetUsername="${5}"
 macOSVersionMajor=$(/usr/bin/sw_vers -productVersion | /usr/bin/awk -F . '{print $1}')
 macOSVersionMinor=$(/usr/bin/sw_vers -productVersion | /usr/bin/awk -F . '{print $2}')
 macOSVersionBuild=$(/usr/bin/sw_vers -productVersion | /usr/bin/awk -F . '{print $3}')
 # Need default password values so the initial logic loops will properly fail when validating passwords. You can store the actual credentials here to skip password prompts entirely, but for security reasons this is not generally recommended. Please don't actually use "foo" as a password, for so many reasons.
 secureTokenAdminPass="foo"
-loggedInUserPass="foo"
+targetUserPassword="foo"
 passwordPrompt="foo"
 
 
@@ -41,15 +63,18 @@ passwordPrompt="foo"
 
 # Exits with error if any required Jamf Pro arguments are undefined.
 check_jamf_pro_arguments () {
+
   if [ -z "$secureTokenAdmin" ]; then
     echo "❌ ERROR: Undefined Jamf Pro argument, unable to proceed."
     exit 74
   fi
+  
 }
 
 
 # Exits if macOS version predates the use of SecureToken functionality.
 check_macos_version () {
+
   # Exit if macOS < 10.
   if [ "$macOSVersionMajor" -lt 10 ]; then
     echo "macOS version ${macOSVersionMajor} predates the use of SecureToken functionality, no action required."
@@ -64,32 +89,46 @@ check_macos_version () {
       exit 0
     fi
   fi
+  
 }
 
 
-# Exits if root is the currently logged-in user, or no logged-in user is detected.
-check_logged_in_user () {
-  if [ "$loggedInUser" = "root" ] || [ -z "$loggedInUser" ]; then
-    echo "Nobody is logged in."
-    exit 0
+# Sets target username to defined value from script parameter, or defaults to logged-in user if undefined.
+check_target_username () {
+
+  if [ -z "$targetUsername" ]; then
+    echo "Target Username undefined. Defaulting to logged-in user..."
+    loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+    # Exit if root is the current logged-in user, or no logged-in user is detected.
+    if [ "$loggedInUser" = "root" ] || [ -z "$loggedInUser" ]; then
+      echo "Nobody is logged in."
+      exit 0
+    else
+      targetUsername="$loggedInUser"
+    fi
   fi
+  echo "Target Username: ${targetUsername}"
+
 }
 
 
-# Exits if $loggedInUser already has SecureToken.
-check_securetoken_logged_in_user () {
-  if /usr/sbin/sysadminctl -secureTokenStatus "$loggedInUser" 2>&1 | /usr/bin/grep -q "ENABLED"; then
-    echo "${loggedInUser} already has a SecureToken. No action required."
+# Exits if target user already has SecureToken.
+check_securetoken_target_user () {
+
+  if /usr/sbin/sysadminctl -secureTokenStatus "$targetUsername" 2>&1 | /usr/bin/grep -q "ENABLED"; then
+    echo "${targetUsername} already has a SecureToken. No action required."
     exit 0
   fi
+  
 }
 
 
 # Exits with error if $secureTokenAdmin does not have SecureToken (unless running macOS 10.15 or later, in which case exit with explanation).
 check_securetoken_admin () {
+
   if /usr/sbin/sysadminctl -secureTokenStatus "$secureTokenAdmin" 2>&1 | /usr/bin/grep -q "DISABLED" ; then
     if [ "$macOSVersionMajor" -gt 10 ] || [ "$macOSVersionMajor" -eq 10 ] && [ "$macOSVersionMinor" -gt 14 ]; then
-      echo "⚠️ Neither ${secureTokenAdmin} nor ${loggedInUser} has a SecureToken, but in macOS 10.15 or later, a SecureToken is automatically granted to the first user to enable FileVault (if no other users have SecureToken), so this may not be necessary. Try enabling FileVault for ${loggedInUser}. If that fails, see what other user on the system has SecureToken, and use its credentials to grant SecureToken to ${loggedInUser}."
+      echo "⚠️ Neither ${secureTokenAdmin} nor ${targetUsername} has a SecureToken, but in macOS 10.15 or later, a SecureToken is automatically granted to the first user to enable FileVault (if no other users have SecureToken), so this may not be necessary. Try enabling FileVault for ${targetUsername}. If that fails, see what other user on the system has SecureToken, and use its credentials to grant SecureToken to ${targetUsername}."
       exit 0
     else
       echo "❌ ERROR: ${secureTokenAdmin} does not have a valid SecureToken, unable to proceed. Please update Jamf Pro policy to target another admin user with SecureToken."
@@ -98,31 +137,37 @@ check_securetoken_admin () {
   else
     echo "✅ Verified ${secureTokenAdmin} has SecureToken."
   fi
+  
 }
 
 
 # Prompts for local password.
 local_account_password_prompt () {
+
   passwordPrompt=$(/usr/bin/osascript -e "set user_password to text returned of (display dialog \"${2}\" default answer \"\" with hidden answer)")
   if [ -z "$passwordPrompt" ]; then
     echo "❌ ERROR: A password was not entered for ${1}, unable to proceed. Please rerun policy; if issue persists, a manual SecureToken add will be required to continue."
     exit 1
   fi
+  
 }
 
 
 # Validates provided password.
 local_account_password_validation () {
+
   if /usr/bin/dscl "/Local/Default" authonly "${1}" "${2}" > "/dev/null" 2>&1; then
     echo "✅ Password successfully validated for ${1}."
   else
     echo "❌ ERROR: Failed password validation for ${1}. Please reenter the password when prompted."
   fi
+  
 }
 
 
 # Adds SecureToken to target user.
 securetoken_add () {
+
   /usr/sbin/sysadminctl \
     -adminUser "${1}" \
     -adminPassword "${2}" \
@@ -140,6 +185,7 @@ securetoken_add () {
     echo "❌ ERROR: Unexpected result, unable to proceed. Please rerun policy; if issue persists, a manual SecureToken add will be required to continue."
     exit 1
   fi
+  
 }
 
 
@@ -151,37 +197,37 @@ securetoken_add () {
 # Check script prerequisites.
 check_jamf_pro_arguments
 check_macos_version
-check_logged_in_user
-check_securetoken_logged_in_user
+check_target_username
+check_securetoken_target_user
 check_securetoken_admin
 
 
-# Add SecureToken to $loggedInUser.
-until /usr/sbin/sysadminctl -secureTokenStatus "$loggedInUser" 2>&1 | /usr/bin/grep -q "ENABLED"; do
+# Add SecureToken to target user.
+until /usr/sbin/sysadminctl -secureTokenStatus "$targetUsername" 2>&1 | /usr/bin/grep -q "ENABLED"; do
 
   # Get $secureTokenAdmin password.
-  echo "${loggedInUser} missing SecureToken, prompting for credentials..."
+  echo "${targetUsername} missing SecureToken, prompting for credentials..."
   until /usr/bin/dscl "/Local/Default" authonly "$secureTokenAdmin" "$secureTokenAdminPass" > "/dev/null" 2>&1; do
-    local_account_password_prompt "$secureTokenAdmin" "Please enter password for ${secureTokenAdmin}. User's credentials are needed to grant a SecureToken to ${loggedInUser}."
+    local_account_password_prompt "$secureTokenAdmin" "Please enter password for ${secureTokenAdmin}. User's credentials are needed to grant a SecureToken to ${targetUsername}."
     secureTokenAdminPass="$passwordPrompt"
     local_account_password_validation "$secureTokenAdmin" "$secureTokenAdminPass"
   done
 
-  # Get $loggedInUser password.
-  until /usr/bin/dscl "/Local/Default" authonly "$loggedInUser" "$loggedInUserPass" > "/dev/null" 2>&1; do
-    local_account_password_prompt "$loggedInUser" "Please enter password for ${loggedInUser} to add SecureToken."
-    loggedInUserPass="$passwordPrompt"
-    local_account_password_validation "$loggedInUser" "$loggedInUserPass"
+  # Get target user's password.
+  until /usr/bin/dscl "/Local/Default" authonly "$targetUsername" "$targetUserPassword" > "/dev/null" 2>&1; do
+    local_account_password_prompt "$targetUsername" "Please enter password for ${targetUsername} to add SecureToken."
+    targetUserPassword="$passwordPrompt"
+    local_account_password_validation "$targetUsername" "$targetUserPassword"
   done
 
   # Add SecureToken using provided credentials.
-  securetoken_add "$secureTokenAdmin" "$secureTokenAdminPass" "$loggedInUser" "$loggedInUserPass"
+  securetoken_add "$secureTokenAdmin" "$secureTokenAdminPass" "$targetUsername" "$targetUserPassword"
 
 done
 
 
 # Echo successful result.
-echo "✅ Verified SecureToken is enabled for ${loggedInUser}."
+echo "✅ Verified SecureToken is enabled for ${targetUsername}."
 
 
 

--- a/Add SecureToken to Target User.sh
+++ b/Add SecureToken to Target User.sh
@@ -41,12 +41,12 @@
 
 
 
-# Jamf Pro script parameter: "SecureToken Admin Username"
-# A local administrator account with SecureToken access.
-secureTokenAdmin="${4}"
 # Jamf Pro script parameter: "Target Username"
 # (optional) A local user account requiring SecureToken. If undefined, script will default to the logged-in user as the target.
-targetUsername="${5}"
+targetUsername="${4}"
+# Jamf Pro script parameter: "SecureToken Admin Username"
+# A local administrator account with SecureToken access.
+secureTokenAdmin="${5}"
 macOSVersionMajor=$(/usr/bin/sw_vers -productVersion | /usr/bin/awk -F . '{print $1}')
 macOSVersionMinor=$(/usr/bin/sw_vers -productVersion | /usr/bin/awk -F . '{print $2}')
 macOSVersionBuild=$(/usr/bin/sw_vers -productVersion | /usr/bin/awk -F . '{print $3}')
@@ -106,6 +106,11 @@ check_target_username () {
     else
       targetUsername="$loggedInUser"
     fi
+  elif id -u "$targetUsername"; then 
+    echo "Confirmed target user exists on this Mac."
+  else 
+    echo "❌ ERROR: User not found on this Mac, unable to proceed: ${targetUsername}"
+    exit 1
   fi
   echo "Target Username: ${targetUsername}"
 
@@ -116,7 +121,7 @@ check_target_username () {
 check_securetoken_target_user () {
 
   if /usr/sbin/sysadminctl -secureTokenStatus "$targetUsername" 2>&1 | /usr/bin/grep -q "ENABLED"; then
-    echo "${targetUsername} already has a SecureToken. No action required."
+    echo "${targetUsername} already has a SecureToken, no action required."
     exit 0
   fi
   

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Mario Panighetti
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Add SecureToken to Logged-In User
+# Add SecureToken to Target User
 
-This script adds a SecureToken to the current logged-in user to prepare the Mac for enabling FileVault. Prompts for password of SecureToken admin (gets SecureToken Admin Username from Jamf Pro script parameter) and logged-in user.
+This script adds a SecureToken to the target local user to prepare the Mac for enabling FileVault. Prompts for password of SecureToken admin (gets SecureToken Admin Username from Jamf Pro script parameter) and target user.
 
 This workflow is required to authorize programmatically-created user accounts (that were not already explicitly given a SecureToken) to enable or use FileVault and unlock disk encryption on APFS-formatted startup volumes.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
-# Add SecureToken  to Logged-In User
+# Add SecureToken to Logged-In User
 
-Adds SecureToken to currently logged-in user. Prompts for password of SecureToken admin (gets SecureToken Admin Username from Jamf Pro script parameter) and logged-in user.
+This script adds a SecureToken to the current logged-in user to prepare the Mac for enabling FileVault. Prompts for password of SecureToken admin (gets SecureToken Admin Username from Jamf Pro script parameter) and logged-in user.
 
 This workflow is required to authorize programmatically-created user accounts (that were not already explicitly given a SecureToken) to enable or use FileVault and unlock disk encryption on APFS-formatted startup volumes.
+
+## Extension Attribute
+
+[SecureToken Status - Logged-In User](SecureToken Status - Logged-In User.sh) is a Jamf Pro extension attribute (see [Computer Extension Attributes](Computer Extension Attributes) in Jamf Pro Documentation). After uploading this extension attribute to Jamf Pro, you can target a policy running this repository's main script at a smart computer group of Macs where the logged-in user has a value of `DISABLED` for this script's output. Once a SecureToken has been added to the target user, this script should report `ENABLED` if everything ran as expected.
 
 ## Credits
 
 - `sysadminctl` SecureToken syntax discovered and formalized in [MacAdmins Slack](https://macadmins.slack.com) #filevault.
+
+## License
+
+This project is offered under an MIT License.

--- a/SecureToken Status - Logged-In User.sh
+++ b/SecureToken Status - Logged-In User.sh
@@ -5,6 +5,29 @@
 #            Name:  SecureToken Status - Logged-In User.sh
 #     Description:  Reports whether SecureToken is enabled for the currently logged-in user.
 #                   https://github.com/mpanighetti/add-securetoken-to-logged-in-user
+#
+#                   MIT License
+#
+#                   Copyright (c) 2017 Mario Panighetti
+#
+#                   Permission is hereby granted, free of charge, to any person obtaining a copy
+#                   of this software and associated documentation files (the "Software"), to deal
+#                   in the Software without restriction, including without limitation the rights
+#                   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#                   copies of the Software, and to permit persons to whom the Software is
+#                   furnished to do so, subject to the following conditions:
+#
+#                   The above copyright notice and this permission notice shall be included in all
+#                   copies or substantial portions of the Software.
+#
+#                   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#                   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#                   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#                   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#                   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#                   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#                   SOFTWARE.
+#
 #          Author:  Mario Panighetti
 #         Created:  2022-02-08
 #   Last Modified:  2025-04-28

--- a/SecureToken Status - Logged-In User.sh
+++ b/SecureToken Status - Logged-In User.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+###
+#
+#            Name:  SecureToken Status - Logged-In User.sh
+#     Description:  Reports whether SecureToken is enabled for the currently logged-in user.
+#                   https://github.com/mpanighetti/add-securetoken-to-logged-in-user
+#          Author:  Mario Panighetti
+#         Created:  2022-02-08
+#   Last Modified:  2025-04-28
+#         Version:  1.0.2
+#
+###
+
+
+
+########## variable-ing ##########
+
+
+
+loggedInUser=$(/usr/bin/stat -f%Su "/dev/console")
+
+
+
+########## main process ##########
+
+
+
+# Check SecureToken for currently logged-in user and report results.
+echo "<result>$(/usr/sbin/sysadminctl -secureTokenStatus "$loggedInUser" 2>&1 | /usr/bin/awk '{print $7}')</result>"
+
+
+
+exit 0


### PR DESCRIPTION
- Add SecureToken to Target User.sh:
  - added option to define target username as script parameter (still uses logged-in user as fallback)
    - updated script name to reflect behavior change
  - added target user existence validation (exits with error if user not found)
- SecureToken Status - Logged-In User.sh
  - added Jamf Pro extension attribute for reporting SecureToken status for the current logged-in user, to be used as criteria to scope a policy to run the main script
- README.md:
  - updated to reflect script behavior changes and extension attribute usage
- added MIT License